### PR TITLE
Make batch size configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,7 @@ spec:
 
 `ES_PASSWORD` - ES password
 
+`ES_BULK_SIZE` - No of items to be read in a scroll request
+
 ## How it works
 Jaeger-dependencies aggregates traces for previous day in directed graph. It queries ES span index for spans who have `span.kind` equal to `server` and have references. After that it counts number of inter-service communications.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -16,7 +16,6 @@ import (
 
 const jaegerSpanPrefix string = "jaeger-span-"
 const jaegerDepPrefix string = "jaeger-dependencies-"
-const bulkReadSize = 500
 
 type Process struct {
 	ServiceName string `json:"serviceName"`
@@ -51,6 +50,7 @@ func GenIndexNameWithPrefix(prefix string) string {
 func main() {
 	esUsername := os.Getenv("ES_USERNAME")
 	esPassword := os.Getenv("ES_PASSWORD")
+	bulkReadSize := os.Getenv("ES_BULK_SIZE")
 	client, err := elastic.NewSimpleClient(
 		elastic.SetURL(os.Getenv("ES_HOST")),
 		elastic.SetBasicAuth(esUsername, esPassword))


### PR DESCRIPTION
The current value of 500 is too low, and it's a hardcoded constant, moving it to a configurable property